### PR TITLE
propper role for door lock

### DIFF
--- a/main.js
+++ b/main.js
@@ -1054,7 +1054,7 @@ class Mercedesme extends utils.Adapter {
 							common: {
 								name: "Door Lock",
 								type: "boolean",
-								role: "indicator",
+								role: "switch.lock",
 								write: true
 							},
 							native: {}


### PR DESCRIPTION
Triggered by an user integrating states to gHome, we noticed the wrong indicator role.
Based on iobroker role documentation (https://github.com/ioBroker/ioBroker/blob/master/doc/STATE_ROLES.md) the attribute should be a switch not indicator :)

indicator : The difference of Indicators from Sensors is that indicators will be shown as small icon. Sensors as a real value.
So the role "indicator" is an read only attribute : "Indicators (boolean, read-only)"

As I understand this value can be used to "switch" (lock/unlock) the car so its not an "read" indicator but "switch" role : Switches (booleans, read-write)

vor Switches the following attributes can be used I "suggest" for this state : 

switch.lock - lock (true - open lock, false - close lock)
switch.lock.door - door lock

(switch door is properly the better naming)

As I noticed, the adapter handles the state different from definition "true - open lock, false - close lock" so I suggest to turn this around before writing the state.
I tried to find the part to write the state but was not able to figure it out where exactly the code par is :)

Kind regards and stay save ! 

~Dutch